### PR TITLE
feat: packed reproducers (pt 2)

### DIFF
--- a/doc/theory_of_operation.md
+++ b/doc/theory_of_operation.md
@@ -106,3 +106,8 @@ copy application executable and its dependencies into trace directory. A special
 files and their packed versions. On Linux, paths, that start with `/dev`,
 `/sys`, or `/proc` are skipped.
 
+### Replaying
+When `dpcpp_trace replay` is invoked, the tool checks for `replay_file_map.json`
+file and sets up hooks for system calls. If the original file is found in the
+map, it will be redirected inside trace directory. It is illegal to pass command
+line arguments to `replay` if trace contains packed reproducer.

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -5,12 +5,14 @@ inline constexpr auto kTracePathEnvVar = "DPCPP_TRACE_DATA_PATH";
 inline constexpr auto kPIDebugStreamName = "sycl.pi.debug";
 
 inline constexpr auto kFilesConfigName = "files_config.json";
+inline constexpr auto kPackedDataPath = "pack";
 
 // Replay config constants
 inline constexpr auto kReplayConfigName = "replay_config.json";
 inline constexpr auto kReplayFileMapConfigName = "replay_file_map.json";
 
 inline constexpr auto kReplayCommand = "command";
+inline constexpr auto kReplayExecutable = "executable";
 inline constexpr auto kReplayArguments = "arguments";
 
 inline constexpr auto kRecordMode = "recordMode";

--- a/src/fork.hpp
+++ b/src/fork.hpp
@@ -14,7 +14,7 @@ public:
   pid() = default;
   explicit pid(pid_t val) : mPid(val) {}
 
-  void wait() {
+  void wait() const {
     int status;
     waitpid(mPid, &status, 0);
     // todo add error handling
@@ -22,7 +22,7 @@ public:
 
   ~pid() = default;
 
-  native_type get_native() { return mPid; }
+  native_type get_native() const noexcept { return mPid; }
 
 private:
   native_type mPid;

--- a/src/trace.hpp
+++ b/src/trace.hpp
@@ -2,21 +2,38 @@
 
 #include "fork.hpp"
 
+#include <cstdint>
 #include <functional>
 #include <string_view>
+
+class OpenHandler {
+public:
+  OpenHandler(pid p, std::uintptr_t stackAddr, unsigned long fileNameReg)
+      : mPid(p), mStackAddr(stackAddr), mFileNameRegister(fileNameReg) {}
+  void execute() const;
+  void execute(std::string_view newFile) const;
+
+private:
+  pid mPid;
+  std::uintptr_t mStackAddr;
+  unsigned long mFileNameRegister;
+};
 
 class Tracer {
 public:
   Tracer(pid);
 
-  void onFileOpen(std::function<void(const std::string &)> handler) {
+  void onFileOpen(
+      std::function<void(const std::string &, const OpenHandler &)> handler) {
     mFileOpenHandler = handler;
   }
 
   void run();
 
 private:
-  std::function<void(const std::string &)> mFileOpenHandler;
+  std::function<void(const std::string &, const OpenHandler &)>
+      mFileOpenHandler =
+          [](const std::string &, const OpenHandler &h) { h.execute(); };
   pid mPid;
 };
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string_view>
+
+inline std::string which(std::string_view path, std::string_view executable) {
+  const std::string separator = ":";
+  size_t lastSeparator = 0;
+  bool done = false;
+  do {
+    size_t nextSeparator = path.find(separator, lastSeparator);
+    size_t length = 0;
+    if (nextSeparator == std::string::npos) {
+      length = path.size() - lastSeparator;
+      done = true;
+    } else {
+      length = nextSeparator - lastSeparator;
+    }
+    auto cand =
+        std::filesystem::path(path.substr(lastSeparator, length)) / executable;
+    std::cout << "Cand is " << cand << std::endl;
+    if (std::filesystem::exists(cand)) {
+      return cand.string();
+    }
+
+    lastSeparator = nextSeparator + 1;
+  } while (!done);
+  throw std::runtime_error("Executable not found " + std::string{executable});
+}

--- a/tests/replay/minimal_packed.cpp
+++ b/tests/replay/minimal_packed.cpp
@@ -1,0 +1,24 @@
+// REQUIRES: linux
+// RUN: echo "1" > %t.txt
+// RUN: %clangxx %s -o %t.exe
+// RUN: %dpcpp_trace record --override -o %t_trace %t.exe -- %t.txt
+// RUN: rm %t.txt
+// RUN: %dpcpp_trace pack %t_trace
+// RUN: %dpcpp_trace replay %t_trace
+
+#include <cstdlib>
+#include <fstream>
+
+int main(int argc, char *argv[]) {
+  if (argc != 2)
+    return EXIT_FAILURE;
+
+  std::ifstream is{argv[1]};
+  int test;
+  is >> test;
+  if (test != 1) {
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -12,3 +12,4 @@ include(CTest)
 include(Catch)
 
 add_subdirectory(options)
+add_subdirectory(misc)

--- a/unittests/misc/CMakeLists.txt
+++ b/unittests/misc/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_dpcpp_trace_executable(MiscTests
+  main.cpp
+  utils.cpp
+  )
+target_link_libraries(MiscTests PRIVATE Catch2::Catch2 options)
+target_include_directories(MiscTests PRIVATE ${PROJECT_SOURCE_DIR}/src)
+catch_discover_tests(MiscTests)
+

--- a/unittests/misc/main.cpp
+++ b/unittests/misc/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/unittests/misc/utils.cpp
+++ b/unittests/misc/utils.cpp
@@ -1,0 +1,17 @@
+#include <catch2/catch.hpp>
+#include <stdexcept>
+
+#include "utils.hpp"
+
+#include <iostream>
+
+TEST_CASE("which finds full path to executable", "[utils]") {
+  std::string_view path{getenv("PATH")};
+
+  std::cout << path << std::endl;
+
+  std::string fullPath = "";
+  REQUIRE_NOTHROW(fullPath = which(path, "ls"));
+
+  REQUIRE(fullPath == "/usr/bin/ls");
+}


### PR DESCRIPTION
This patch adds ability to replay packed traces by overriding `open` system calls and redirecting them inside the trace storage.