### PR TITLE
refactor: split launch and start

### DIFF
--- a/include/utils/Tracer.hpp
+++ b/include/utils/Tracer.hpp
@@ -39,6 +39,7 @@ public:
 
   virtual ~Tracer() = default;
 
+  virtual void start() = 0;
   virtual int wait() = 0;
   virtual void kill() = 0;
   virtual void interrupt() = 0;
@@ -64,6 +65,7 @@ public:
   void onFileOpen(onFileOpenHandler) final;
   void onStat(onStatHandler) final;
 
+  void start() final;
   int wait() final;
   void kill() final;
   void interrupt() final;

--- a/lib/debug/host/HostDebugger.cpp
+++ b/lib/debug/host/HostDebugger.cpp
@@ -170,6 +170,7 @@ int HostDebugger::wait() {
   } while (type != eStateExited || type != eStateCrashed);
   return 0;
 }
+void HostDebugger::start() {}
 void HostDebugger::kill() {}
 void HostDebugger::interrupt() {}
 

--- a/lib/debug/host/HostDebugger.hpp
+++ b/lib/debug/host/HostDebugger.hpp
@@ -39,7 +39,7 @@ public:
 
   bool isAttached() final;
 
-
+  void start() final;
   int wait() final;
   void kill() final;
   void interrupt() final;

--- a/src/record.cpp
+++ b/src/record.cpp
@@ -129,12 +129,12 @@ void record(const options &opts) {
       });
 
   tracer.launch(executable, execArgs, env);
+  tracer.start();
+  int code = tracer.wait();
 
   std::ofstream filesOut{opts.output() / kFilesConfigName};
   filesOut << files.dump(4);
   filesOut.close();
-
-  int code = tracer.wait();
 
   if (code != 0)
     throw std::runtime_error("Child application exited with code " +

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -195,5 +195,6 @@ void replay(const options &opts) {
   }
 
   tracer.launch(executable, execArgs, env);
+  tracer.start();
   tracer.wait();
 }

--- a/unittests/utils/NativeTracer.cpp
+++ b/unittests/utils/NativeTracer.cpp
@@ -30,6 +30,7 @@ TEST_CASE("can fork processes", "[NativeTracer]") {
 
   NativeTracer tracer;
   tracer.fork(start, false);
+  tracer.start();
   tracer.wait();
 
   std::ifstream is{fs::temp_directory_path() / kForkTestFilename};
@@ -57,6 +58,7 @@ TEST_CASE("can trace files being open", "[NativeTracer]") {
       test = true;
   });
   tracer.fork(start, false);
+  tracer.start();
   tracer.wait();
 
   std::ifstream is{fs::temp_directory_path() / kOpenTestFilename};
@@ -86,6 +88,7 @@ TEST_CASE("can trace files being stat", "[NativeTracer]") {
       test = true;
   });
   tracer.fork(start, false);
+  tracer.start();
   tracer.wait();
 
   std::ifstream is{fs::temp_directory_path() / kStatTestFilename};
@@ -119,6 +122,7 @@ TEST_CASE("can replace filenames", "[NativeTracer]") {
     }
   });
   tracer.fork(start, false);
+  tracer.start();
   tracer.wait();
 
   std::ifstream is1{fs::temp_directory_path() / kReplaceTestFilename1};
@@ -145,6 +149,7 @@ TEST_CASE("can catch signals", "[NativeTracer]") {
   };
   NativeTracer tracer;
   tracer.fork(start, false);
+  tracer.start();
   int result = tracer.wait();
 
   REQUIRE(result != 0);
@@ -157,6 +162,7 @@ TEST_CASE("can capture exit code", "[NativeTracer]") {
   };
   NativeTracer tracer;
   tracer.fork(start, false);
+  tracer.start();
   int result = tracer.wait();
 
   REQUIRE(result == 42);


### PR DESCRIPTION
When in debug mode, users typically do not want applications to run
before some initial setup is performed. Refactor Tracer interface to
account for this.